### PR TITLE
Fixed links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ To adjust the BPM (Beats Per Minute):
 
 ### Credits
 
-- Sound assets for notes generated with Google's TTS on [freetts.com](https://freetts.com/])
-- [Tic](https://freesound.org/people/MrOwn1/sounds/110314/]) and [Toc](https://freesound.org/people/fellur/sounds/429721/]) found on [freesound.org](https://freesound.org])
+- Sound assets for notes generated with Google's TTS on [freetts.com](https://freetts.com/)
+- [Tic](https://freesound.org/people/MrOwn1/sounds/110314/) and [Toc](https://freesound.org/people/fellur/sounds/429721/) found on [freesound.org](https://freesound.org)


### PR DESCRIPTION
The square brackets added `%5D` to the url, resulting in 404